### PR TITLE
[pip-tools] Fix problems by installing pip-tools and wheel outside venv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get clean && \
         python3-setuptools \
         python3-virtualenv && \
     pip3 install --upgrade pip && \
+    pip3 install pip-tools wheel && \
     apt-get install --no-install-recommends -y \
       libxml2-dev \
       libxslt1-dev \
@@ -52,7 +53,6 @@ RUN python3 -m virtualenv --python=python3 $VIRTUAL_ENV_DIR && \
     sed -i "/^ENV_PATH/c\ENV_PATH      PATH=$PATH" /etc/login.defs && \
     # Replace the environment PATH for new su implementation (Ubuntu 20 up)
     sed -i "/^PATH/c\EPATH=\"$PATH\"" /etc/environment
-RUN pip3 install pip-tools wheel
 
 COPY ./requirements.txt $BACKEND_DIR/requirements.txt
 RUN pip-sync $BACKEND_DIR/requirements.txt


### PR DESCRIPTION
This solves the problem where if you install wheel and pip-tools inside the venv and then you'll run `pip-sync requirements.txt` it will try to uninstall all unnecessary packages (unnecessary = not in the requirements.txt). This means `pip-sync` will uninstall itself (`pip-tools`) and `wheel` (necessary to build wheel python packages)